### PR TITLE
Fix ripple's opacity and center it

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "iron-flex-layout": "polymerelements/iron-flex-layout#^0.9.0",
     "iron-icon": "polymerelements/iron-icon#^0.9.0",
     "iron-icons": "polymerelements/iron-icons#^0.9.0",
-    "paper-behaviors": "polymerelements/paper-behaviors#^0.9.0",
+    "paper-behaviors": "polymerelements/paper-behaviors#^0.9.3",
     "paper-ripple": "polymerelements/paper-ripple#^0.9.0",
     "paper-styles": "polymerelements/paper-styles#^0.9.0",
     "polymer": "Polymer/polymer#^0.9.0"

--- a/demo/index.html
+++ b/demo/index.html
@@ -53,7 +53,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       paper-icon-button.custom {
-        color: #a9edff;
+        color: #00CAFF;
       }
     </style>
 

--- a/paper-icon-button.html
+++ b/paper-icon-button.html
@@ -8,6 +8,19 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS
 -->
 
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-icon/iron-icon.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
+<link rel="import" href="../paper-styles/default-theme.html">
+<link rel="import" href="../paper-behaviors/paper-button-behavior.html">
+<link rel="import" href="../paper-ripple/paper-ripple.html">
+
+<style is="custom-style">
+  :root {
+    --paper-icon-button-disabled-text: var(--disabled-text-color);
+  }
+</style>
+
 <!--
 @group Paper Elements
 
@@ -54,19 +67,6 @@ The opacity of the ripple is not customizable via CSS.
 @homepage github.io
 -->
 
-<link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-icon/iron-icon.html">
-<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
-<link rel="import" href="../paper-styles/default-theme.html">
-<link rel="import" href="../paper-behaviors/paper-button-behavior.html">
-<link rel="import" href="../paper-ripple/paper-ripple.html">
-
-<style is="custom-style">
-  * {
-    --paper-icon-button-disabled-text: var(--disabled-text-color);
-  }
-</style>
-
 <dom-module id="paper-icon-button">
   <style>
     :host {
@@ -93,7 +93,7 @@ The opacity of the ripple is not customizable via CSS.
     }
   </style>
   <template>
-    <paper-ripple class="circle" recenters></paper-ripple>
+    <paper-ripple class="circle" initial-opacity="0.1" center></paper-ripple>
     <iron-icon id="icon" src="[[src]]" icon="[[icon]]"></iron-icon>
   </template>
 </dom-module>

--- a/test/a11y.html
+++ b/test/a11y.html
@@ -52,12 +52,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     test('aria-disabled is set', function() {
-      assert.ok(b2.hasAttribute('aria-disabled'));
+      assert.strictEqual(b2.getAttribute('aria-disabled'), 'true');
       b2.removeAttribute('disabled');
-      assert.ok(!b2.hasAttribute('aria-disabled'));
+      assert.strictEqual(b2.getAttribute('aria-disabled'), 'false');
     });
-
-    test('aria-label is set');
 
     test('user-defined aria-label is preserved', function() {
       assert.strictEqual(b3.getAttribute('aria-label'), 'custom');

--- a/test/basic.html
+++ b/test/basic.html
@@ -50,7 +50,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
     function approxEqual(p1, p2) {
-      return Math.round(p1.left) == Math.round(p2.left) && Math.round(p1.top) == Math.round(p2.top);
+      return Math.abs(p1.left - p2.left) <= 1 && Math.abs(p1.top-p2.top) <= 1;
     }
 
     setup(function() {
@@ -59,16 +59,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     test('applies an icon specified by the `icon` attribute', function() {
-      assert.strictEqual(!!b1.$.icon.usesSrcAttribute, false);
+      assert.strictEqual(!!b1.$.icon.src, false);
       assert.ok(Polymer.dom(b1.$.icon.root).querySelector('svg'));
     });
 
     test('applies an icon specified by the `src` attribute', function() {
-      assert.strictEqual(!!b2.$.icon.usesSrcAttribute, true);
-      assert.ok(b2.$.icon.srcImgElement);
+
+      assert.strictEqual(!!b2.$.icon.src, true);
+      assert.ok(b2.$.icon.src);
     });
 
-    xtest('renders correctly independent of line height', function() {
+    test('renders correctly independent of line height', function() {
       assert.ok(approxEqual(centerOf(b1.$.icon), centerOf(b1)));
     });
   </script>


### PR DESCRIPTION
**Material design spec audit https://github.com/PolymerElements/paper-icon-button/issues/11**
* Reduce the opacity to `0.15`
* Center the ripple. This property requires https://github.com/PolymerElements/paper-ripple/pull/18
* Change selector `*` to `:root`
* Fix tests.

cc @cdata @morethanreal @notwaldorf 