### PR TITLE
add focus state

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -25,7 +25,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       paper-icon-button {
+        margin-left: 30px;
         display: block;
+        width: 24px;
         text-align: center;
       }
 
@@ -63,6 +65,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       paper-icon-button.green:hover {
         background: var(--paper-green-50);
         border-radius: 50%;
+      }
+
+      paper-icon-button.huge {
+        margin-left: 0px;
+        width: 100px;
+        --paper-icon-button-ink-color: var(--paper-indigo-500);
       }
 
       paper-icon-button.huge::shadow #icon {

--- a/paper-icon-button.html
+++ b/paper-icon-button.html
@@ -13,6 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../paper-styles/default-theme.html">
 <link rel="import" href="../paper-behaviors/paper-button-behavior.html">
+<link rel="import" href="../paper-behaviors/paper-radio-button-behavior.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">
 
 <style is="custom-style">
@@ -44,8 +45,7 @@ Example:
     <paper-icon-button icon="favorite"></paper-icon-button>
     <paper-icon-button src="star.png"></paper-icon-button>
 
-Styling
--------
+###Styling
 
 Style the button with CSS as you would a normal DOM element. If you are using the icons
 provided by `iron-icons`, they will inherit the foreground color of the button.
@@ -63,6 +63,15 @@ customize the color using this selector:
 
 The opacity of the ripple is not customizable via CSS.
 
+The following custom properties and mixins are available for styling:
+
+Custom property | Description | Default
+----------------|-------------|----------
+`--paper-icon-button-disabled-text` | The color of the disabled button | `--primary-text-color`
+`--paper-icon-button-ink-color` | Selected/focus ripple color | `--default-primary-color`
+`--paper-icon-button` | Mixin for a button | `{}`
+`--paper-icon-button-disabled` | Mixin for a disabled button | `{}`
+
 @group Paper Elements
 @element paper-icon-button
 @demo demo/index.html
@@ -70,6 +79,7 @@ The opacity of the ripple is not customizable via CSS.
 
 <dom-module id="paper-icon-button">
   <style>
+
     :host {
       display: inline-block;
       position: relative;
@@ -85,16 +95,20 @@ The opacity of the ripple is not customizable via CSS.
       @apply(--paper-icon-button);
     }
 
+    :host #ink {
+      color: var(--paper-icon-button-ink-color, --primary-text-color);
+      opacity: 0.6;
+    }
+
     :host([disabled]) {
-      color: var(--paper-icon-button-disabled-text);
+      color: var(--paper-icon-button-disabled-text, #fff);
       pointer-events: none;
       cursor: auto;
-
       @apply(--paper-icon-button-disabled);
     }
   </style>
   <template>
-    <paper-ripple class="circle" initial-opacity="0.1" center></paper-ripple>
+    <paper-ripple id="ink" class="circle" center></paper-ripple>
     <iron-icon id="icon" src="[[src]]" icon="[[icon]]"></iron-icon>
   </template>
 </dom-module>
@@ -103,7 +117,8 @@ The opacity of the ripple is not customizable via CSS.
     is: 'paper-icon-button',
 
     behaviors: [
-      Polymer.PaperButtonBehavior
+      Polymer.PaperButtonBehavior,
+      Polymer.PaperRadioButtonBehavior
     ],
 
     properties: {


### PR DESCRIPTION
This fixes https://github.com/PolymerElements/paper-icon-button/issues/9. I stole the focus state from `paper-radio-button` and brethren, so it looks like this:

![screen shot 2015-05-26 at 5 11 51 pm](https://cloud.githubusercontent.com/assets/1369170/7826104/89cf3d0a-03ca-11e5-9968-e96e9d87ef87.png)
