### PR TITLE
add alt attribute for a11y and fix double-tap event

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -92,48 +92,48 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <div>
         <h4>Enabled</h4>
         <div class="horizontal-section">
-          <paper-icon-button icon="menu" title="menu"></paper-icon-button>
-          <paper-icon-button icon="favorite" title="heart"></paper-icon-button>
-          <paper-icon-button icon="arrow-back" title="arrow-back"></paper-icon-button>
-          <paper-icon-button icon="arrow-forward" title="arrow-forward"></paper-icon-button>
-          <paper-icon-button icon="clear" title="clear"></paper-icon-button>
-          <paper-icon-button icon="polymer" title="polymer"></paper-icon-button>
-          <paper-icon-button src="https://assets-cdn.github.com/images/modules/logos_page/Octocat.png" aria-label="octocat" title="octocat"></paper-icon-button>
+          <paper-icon-button icon="menu" alt="menu" title="menu"></paper-icon-button>
+          <paper-icon-button icon="favorite" alt="heart" title="heart"></paper-icon-button>
+          <paper-icon-button icon="arrow-back" alt="arrow-back" title="arrow-back"></paper-icon-button>
+          <paper-icon-button icon="arrow-forward" alt="arrow-forward" title="arrow-forward"></paper-icon-button>
+          <paper-icon-button icon="clear" alt="clear" title="clear"></paper-icon-button>
+          <paper-icon-button icon="polymer" alt="polymer" title="polymer"></paper-icon-button>
+          <paper-icon-button src="https://assets-cdn.github.com/images/modules/logos_page/Octocat.png" alt="octocat" title="octocat"></paper-icon-button>
         </div>
       </div>
 
       <div>
         <h4>Disabled</h4>
         <div class="horizontal-section">
-          <paper-icon-button icon="menu" title="menu" disabled></paper-icon-button>
-          <paper-icon-button icon="favorite" title="heart" disabled></paper-icon-button>
-          <paper-icon-button icon="arrow-back" title="arrow-back" disabled></paper-icon-button>
-          <paper-icon-button icon="arrow-forward" title="arrow-forward" disabled></paper-icon-button>
-          <paper-icon-button icon="clear" title="clear" disabled></paper-icon-button>
-          <paper-icon-button icon="polymer" title="polymer" disabled></paper-icon-button>
-          <paper-icon-button src="https://assets-cdn.github.com/images/modules/logos_page/Octocat.png" aria-label="octocat" title="octocat" disabled></paper-icon-button>
+          <paper-icon-button icon="menu" alt="menu" disabled></paper-icon-button>
+          <paper-icon-button icon="favorite" alt="heart" disabled></paper-icon-button>
+          <paper-icon-button icon="arrow-back" alt="arrow-back" disabled></paper-icon-button>
+          <paper-icon-button icon="arrow-forward" alt="arrow-forward" disabled></paper-icon-button>
+          <paper-icon-button icon="clear" alt="clear" disabled></paper-icon-button>
+          <paper-icon-button icon="polymer" alt="polymer" disabled></paper-icon-button>
+          <paper-icon-button src="https://assets-cdn.github.com/images/modules/logos_page/Octocat.png" alt="octocat" disabled></paper-icon-button>
         </div>
       </div>
 
       <div>
         <h4>Color</h4>
         <div class="horizontal-section">
-          <paper-icon-button icon="menu" title="menu" class="blue"></paper-icon-button>
-          <paper-icon-button icon="favorite" title="heart" class="red"></paper-icon-button>
-          <paper-icon-button icon="arrow-back" title="arrow-back" class="orange"></paper-icon-button>
-          <paper-icon-button icon="arrow-forward" title="arrow-forward" class="green"></paper-icon-button>
-          <paper-icon-button icon="clear" title="clear" class="blue"></paper-icon-button>
-          <paper-icon-button icon="polymer" title="polymer" class="red"></paper-icon-button>
-          <paper-icon-button class="blue" src="https://assets-cdn.github.com/images/modules/logos_page/Octocat.png" aria-label="octocat" title="octocat"></paper-icon-button>
+          <paper-icon-button icon="menu" alt="menu" class="blue"></paper-icon-button>
+          <paper-icon-button icon="favorite" alt="heart" class="red"></paper-icon-button>
+          <paper-icon-button icon="arrow-back" alt="arrow-back" class="orange"></paper-icon-button>
+          <paper-icon-button icon="arrow-forward" alt="arrow-forward" class="green"></paper-icon-button>
+          <paper-icon-button icon="clear" alt="clear" class="blue"></paper-icon-button>
+          <paper-icon-button icon="polymer" alt="polymer" class="red"></paper-icon-button>
+          <paper-icon-button class="blue" src="https://assets-cdn.github.com/images/modules/logos_page/Octocat.png" alt="octocat"></paper-icon-button>
         </div>
       </div>
 
       <div>
         <h4>Size</h4>
         <div class="horizontal-section">
-          <paper-icon-button icon="favorite" title="heart" class="huge"></paper-icon-button>
+          <paper-icon-button icon="favorite" alt="heart" class="huge"></paper-icon-button>
           <br><br><br>
-          <paper-icon-button icon="polymer" title="polymer" class="huge"></paper-icon-button>
+          <paper-icon-button icon="polymer" alt="polymer" class="huge"></paper-icon-button>
         </div>
       </div>
     </div>

--- a/paper-icon-button.html
+++ b/paper-icon-button.html
@@ -107,15 +107,19 @@ Custom property | Description | Default
   </style>
   <template>
     <paper-ripple id="ink" class="circle" center></paper-ripple>
-    <iron-icon id="icon" src="[[src]]" icon="[[icon]]"></iron-icon>
+    <iron-icon id="icon" src="[[src]]" icon="[[icon]]" alt$="[[alt]]"></iron-icon>
   </template>
 </dom-module>
 <script>
   Polymer({
     is: 'paper-icon-button',
 
+    hostAttributes: {
+      role: 'button',
+      tabindex: '0'
+    },
+
     behaviors: [
-      Polymer.PaperButtonBehavior,
       Polymer.PaperInkyFocusBehavior
     ],
 
@@ -135,6 +139,23 @@ Custom property | Description | Default
        */
       icon: {
         type: String
+      },
+
+      /**
+       * Specifies the alternate text for the button, for accessibility.
+       */
+      alt: {
+        type: String,
+        observer: "_altChanged"
+      }
+    },
+
+    _altChanged: function(newValue, oldValue) {
+      var label = this.getAttribute('aria-label');
+
+      // Don't stomp over a user-set aria-label.
+      if (!label || oldValue == label) {
+        this.setAttribute('aria-label', newValue);
       }
     }
   });

--- a/test/a11y.html
+++ b/test/a11y.html
@@ -30,6 +30,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <paper-icon-button id="iconButton1" icon="add"></paper-icon-button>
       <paper-icon-button id="iconButton2" icon="add" disabled></paper-icon-button>
       <paper-icon-button id="iconButton3" icon="add" aria-label="custom"></paper-icon-button>
+      <paper-icon-button id="iconButton4" icon="add" alt="alt text"></paper-icon-button>
+      <paper-icon-button id="iconButton5" icon="add" aria-label="custom" alt="alt text" ></paper-icon-button>
     </template>
   </test-fixture>
 
@@ -38,6 +40,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var b1;
     var b2;
     var b3;
+    var b4;
+    var b5;
 
     setup(function() {
       var iconButtons = fixture('A11yIconButtons');
@@ -45,6 +49,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       b1 = iconButtons[0];
       b2 = iconButtons[1];
       b3 = iconButtons[2];
+      b4 = iconButtons[3];
+      b5 = iconButtons[4];
     });
 
     test('aria role is a button', function() {
@@ -61,6 +67,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.strictEqual(b3.getAttribute('aria-label'), 'custom');
       b3.icon = 'arrow-forward';
       assert.strictEqual(b3.getAttribute('aria-label'), 'custom');
+    });
+
+    test('alt attribute is used for the aria-label', function() {
+      assert.strictEqual(b4.getAttribute('aria-label'), 'alt text');
+      b4.icon = 'arrow-forward';
+      assert.strictEqual(b4.getAttribute('aria-label'), 'alt text');
+    });
+
+    test('aria-label wins over alt attribute', function() {
+      assert.strictEqual(b5.getAttribute('aria-label'), 'custom');
+      b5.icon = 'arrow-forward';
+      b5.alt = 'other alt'
+      assert.strictEqual(b5.getAttribute('aria-label'), 'custom');
+    });
+
+    test('alt attribute can be updated', function() {
+      assert.strictEqual(b4.getAttribute('aria-label'), 'alt text');
+      b4.alt = 'alt again';
+      assert.strictEqual(b4.getAttribute('aria-label'), 'alt again');
     });
 
   </script>


### PR DESCRIPTION
- adds alt attribute for a11y to fix https://github.com/PolymerElements/paper-icon-button/issues/4
- removes the duplicate button behaviour and moves the host attributes into the button to fix https://github.com/PolymerElements/paper-icon-button/issues/19 and  https://github.com/PolymerElements/paper-icon-button/issues/20
