### PR TITLE
inky focus behaviour got renamed

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "polymer": "Polymer/polymer#^1.0.0"
   },
   "devDependencies": {
-    "iron-component-page": "polymerelements/iron-component-page#^0.9.0",
+    "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
     "test-fixture": "polymerelements/test-fixture#^1.0.0",
     "web-component-tester": "*",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"

--- a/paper-icon-button.html
+++ b/paper-icon-button.html
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../paper-styles/default-theme.html">
 <link rel="import" href="../paper-behaviors/paper-button-behavior.html">
-<link rel="import" href="../paper-behaviors/paper-radio-button-behavior.html">
+<link rel="import" href="../paper-behaviors/paper-inky-focus-behavior.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">
 
 <style is="custom-style">
@@ -116,7 +116,7 @@ Custom property | Description | Default
 
     behaviors: [
       Polymer.PaperButtonBehavior,
-      Polymer.PaperRadioButtonBehavior
+      Polymer.PaperInkyFocusBehavior
     ],
 
     properties: {


### PR DESCRIPTION
This catches up to the behaviour getting renamed in https://github.com/PolymerElements/paper-behaviors/pull/25

Also drive-by fixed the wrong tag in `bower.json`.

/cc @blasten 