### PR TITLE
Added tooltip property which adds a paper-tooltip element

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,15 @@ from the icon set to use.
 See [`iron-iconset`](#iron-iconset) for more information about
 how to use a custom icon set.
 
+Use `tooltip` to add a [`paper-tooltip`](#paper-tooltip) element with the desired text.
+
 Example:
 
 ```html
 <link href="path/to/iron-icons/iron-icons.html" rel="import">
 
 <paper-icon-button icon="favorite"></paper-icon-button>
-<paper-icon-button src="star.png"></paper-icon-button>
+<paper-icon-button src="star.png" tooltip="Rate"></paper-icon-button>
 ```
 
 Styling

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,8 @@
     "iron-icons": "PolymerElements/iron-icons#^1.0.0",
     "paper-behaviors": "PolymerElements/paper-behaviors#^1.0.0",
     "paper-ripple": "PolymerElements/paper-ripple#^1.0.0",
-    "paper-styles": "PolymerElements/paper-styles#^1.0.0"
+    "paper-styles": "PolymerElements/paper-styles#^1.0.0",
+    "paper-tooltip": "PolymerElements/paper-tooltip#^1.0.0"
   },
   "devDependencies": {
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",

--- a/demo/index.html
+++ b/demo/index.html
@@ -98,7 +98,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <paper-icon-button icon="arrow-forward" alt="arrow-forward" title="arrow-forward"></paper-icon-button>
           <paper-icon-button icon="clear" alt="clear" title="clear"></paper-icon-button>
           <paper-icon-button icon="polymer" alt="polymer" title="polymer"></paper-icon-button>
-          <paper-icon-button src="https://assets-cdn.github.com/images/modules/logos_page/Octocat.png" alt="octocat" title="octocat"></paper-icon-button>
+          <paper-icon-button src="https://assets-cdn.github.com/images/modules/logos_page/Octocat.png" alt="octocat" tooltip="Fork on GitHub"></paper-icon-button>
         </div>
       </div>
 

--- a/paper-icon-button.html
+++ b/paper-icon-button.html
@@ -15,6 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../paper-behaviors/paper-button-behavior.html">
 <link rel="import" href="../paper-behaviors/paper-inky-focus-behavior.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">
+<link rel="import" href="../paper-tooltip/paper-tooltip.html">
 
 <!--
 Material Design: <a href="http://www.google.com/design/spec/components/buttons.html">Buttons</a>
@@ -30,12 +31,14 @@ from the icon set to use.
 See [`iron-iconset`](#iron-iconset) for more information about
 how to use a custom icon set.
 
+Use `tooltip` to add a [`paper-tooltip`](#paper-tooltip) element with the desired text.
+
 Example:
 
     <link href="path/to/iron-icons/iron-icons.html" rel="import">
 
     <paper-icon-button icon="favorite"></paper-icon-button>
-    <paper-icon-button src="star.png"></paper-icon-button>
+    <paper-icon-button src="star.png" tooltip="Rate"></paper-icon-button>
 
 ###Styling
 
@@ -101,8 +104,13 @@ Custom property | Description | Default
     }
   </style>
   <template>
-    <paper-ripple id="ink" class="circle" center></paper-ripple>
-    <iron-icon id="icon" src="[[src]]" icon="[[icon]]" alt$="[[alt]]"></iron-icon>
+    <template is="dom-if" if="{{tooltip}}">
+      <paper-tooltip margin-top="0">{{tooltip}}</paper-tooltip>
+    </template>
+    <div>
+      <paper-ripple id="ink" class="circle" center></paper-ripple>
+      <iron-icon id="icon" src="[[src]]" icon="[[icon]]" alt$="[[alt]]"></iron-icon>
+    </div>
   </template>
 </dom-module>
 <script>
@@ -142,6 +150,13 @@ Custom property | Description | Default
       alt: {
         type: String,
         observer: "_altChanged"
+      },
+
+      /**
+       * The text being used in a paper-tooltip. The tooltip won't be shown if this property is undefined or the whole element is disabled.
+       */
+      tooltip: {
+        type: String
       }
     },
 


### PR DESCRIPTION
I've added the property `tooltip`. If set, there's a paper-tooltip element in the paper-icon-button. The tooltip text is the value of the property.

At the Material Design Specs, tooltips are always demonstrated with icon buttons. So why not make it easier to add tooltips directly to the icon button, if that's the main use?