### PR TITLE
fix default size

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -27,7 +27,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       paper-icon-button {
         margin-left: 30px;
         display: block;
-        width: 24px;
         text-align: center;
       }
 

--- a/paper-icon-button.html
+++ b/paper-icon-button.html
@@ -78,6 +78,7 @@ Custom property | Description | Default
         cursor: pointer;
         z-index: 0;
 
+        width: 24px;
         @apply(--paper-icon-button);
       }
 


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-icon-button/issues/45

(without a default size, the out-of-the-box `paper-icon-button` is enormous)