### PR TITLE
fix border-box sizing

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -68,8 +68,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       paper-icon-button.huge {
         margin-left: 0px;
-        width: 100px;
-        height: 100px;
+        width: 116px;
+        height: 116px;
         --paper-icon-button-ink-color: var(--paper-indigo-500);
       }
     </style>

--- a/paper-icon-button.html
+++ b/paper-icon-button.html
@@ -77,8 +77,13 @@ Custom property | Description | Default
         user-select: none;
         cursor: pointer;
         z-index: 0;
+        line-height: 1;
+        
+        width: 40px;
+        height: 40px;
 
-        width: 24px;
+        /* Because of polymer/2558, this style has lower specificity than * */
+        box-sizing: border-box !important;
         @apply(--paper-icon-button);
       }
 


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-icon-button/issues/50

Looks the same before and after.

Before:
<img width="426" alt="old" src="https://cloud.githubusercontent.com/assets/1369170/10441727/06a6b634-7101-11e5-936e-aea149836412.png">

After:
<img width="444" alt="new" src="https://cloud.githubusercontent.com/assets/1369170/10441734/0c4ed0e4-7101-11e5-85d8-f0eb5c436948.png">
