### PR TITLE
re-add a paper-icon-button-light version

### DIFF
--- a/demo/paper-icon-button-light.html
+++ b/demo/paper-icon-button-light.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+    <title>paper-icon-button-light demo</title>
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+    <link rel="import" href="../../iron-icon/iron-icon.html">
+    <link rel="import" href="../../iron-icons/iron-icons.html">
+    <link rel="import" href="../../paper-styles/color.html">
+    <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+    <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
+    <link rel="import" href="../paper-icon-button-light.html">
+
+    <custom-style>
+      <style is="custom-style" include="demo-pages-shared-styles"></style>
+    </custom-style>
+  </head>
+  <body unresolved>
+    <div class="vertical-section-container centered">
+      <h3>paper-icon-button-light can contain iron-icons or external images and can be disabled</h3>
+      <demo-snippet class="centered-demo">
+        <template>
+          <custom-style>
+            <style is="custom-style">
+              paper-icon-button-light {
+                width: 40px;
+                height: 40px;
+                margin: 10px;
+              }
+              paper-icon-button-light img {
+                width: 24px;
+                height: 24px;
+              }
+            </style>
+          </custom-style>
+
+          <paper-icon-button-light>
+            <button title="heart">
+              <iron-icon icon="favorite"></iron-icon>
+            </button>
+          </paper-icon-button-light>
+
+          <paper-icon-button-light>
+            <button title="octocat">
+              <img src="https://assets-cdn.github.com/images/modules/logos_page/Octocat.png" alt="octocat">
+            </button>
+          </paper-icon-button-light>
+
+          <paper-icon-button-light>
+            <button title="reply" disabled>
+              <iron-icon icon="reply"></iron-icon>
+            </button>
+          </paper-icon-button-light>
+        </template>
+      </demo-snippet>
+    </div>
+  </body>
+</html>

--- a/paper-icon-button-light.html
+++ b/paper-icon-button-light.html
@@ -59,7 +59,7 @@ Custom property | Description | Default
         @apply(--paper-icon-button-light-ripple);
       }
 
-      :host ::slotted(button) {
+      :host > ::slotted(button) {
         position: relative;
         width: 100%;
         height: 100%;
@@ -75,13 +75,13 @@ Custom property | Description | Default
         -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
         -webkit-tap-highlight-color: transparent;
       }
-      :host ::slotted(button[disabled]) {
+      :host > ::slotted(button[disabled]) {
         color: #9b9b9b;
         pointer-events: none;
         cursor: auto;
       }
     </style>
-    <slot></slot>
+    <slot id="content"></slot>
   </template>
 
   <script>
@@ -92,20 +92,21 @@ Custom property | Description | Default
         Polymer.PaperRippleBehavior
       ],
 
-      listeners: {
-        'down': '_rippleDown',
-        'up': '_rippleUp'
-      },
-
       ready: function() {
-        // Assume the button has already been distributed.
-        var button = this.getEffectiveChildren()[0];
-        this._rippleContainer = button;
+        Polymer.RenderStatus.afterNextRender(this, () => {
+          // Add lazy host listeners
+          this.addEventListener('down', this._rippleDown.bind(this));
+          this.addEventListener('up', this._rippleUp.bind(this));
 
-        // We need to set the focus/blur listeners on the distributed button,
-        // not the host, since the host isn't focusable.
-        button.addEventListener('focus', this._rippleDown.bind(this));
-        button.addEventListener('blur', this._rippleUp.bind(this));
+          // Assume the button has already been distributed.
+          var button = this.getEffectiveChildren()[0];
+          this._rippleContainer = button;
+          
+          // We need to set the focus/blur listeners on the distributed button,
+          // not the host, since the host isn't focusable.
+          button.addEventListener('focus', this._rippleDown.bind(this));
+          button.addEventListener('blur', this._rippleUp.bind(this));
+        });
       },
       _rippleDown: function() {
         this.getRipple().uiDownAction();

--- a/paper-icon-button-light.html
+++ b/paper-icon-button-light.html
@@ -96,11 +96,13 @@ Custom property | Description | Default
 
       attached: function() {
         // Assume the button has already been distributed.
-        this._button = this.getEffectiveChildren()[0];
-        this._rippleContainer = this._button;
+        var button = this.getEffectiveChildren()[0];
+        this._rippleContainer = button;
 
-        this._button.addEventListener('focus', this._rippleDown.bind(this));
-        this._button.addEventListener('blur', this._rippleUp.bind(this));
+        // We need to set the focus/blur listeners on the distributed button,
+        // not the host, since the host isn't focusable.
+        button.addEventListener('focus', this._rippleDown.bind(this));
+        button.addEventListener('blur', this._rippleUp.bind(this));
       },
       _rippleDown: function() {
         this.getRipple().uiDownAction();

--- a/paper-icon-button-light.html
+++ b/paper-icon-button-light.html
@@ -81,7 +81,7 @@ Custom property | Description | Default
         cursor: auto;
       }
     </style>
-    <slot id="content"></slot>
+    <slot></slot>
   </template>
 
   <script>

--- a/paper-icon-button-light.html
+++ b/paper-icon-button-light.html
@@ -1,0 +1,124 @@
+<!--
+@license
+Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../paper-behaviors/paper-ripple-behavior.html">
+
+<!--
+This is a lighter version of `paper-icon-button`. Its goal is performance, not
+developer ergonomics, so as a result it has fewer features than `paper-icon-button`
+itself. To use it, you must distribute a `button` containing the `iron-icon` you
+want to use:
+
+<link rel="import" href="../iron-icon/iron-icon.html">
+<link rel="import" href="../paper-icon-button/paper-icon-button-light.html">
+<link rel="import" href="../iron-icons/iron-icons.html">
+
+<paper-icon-button-light>
+  <button title="heart">
+    <iron-icon icon="favorite"></iron-icon>
+  </button>
+</paper-icon-button-light>
+
+Note that the `title`/`disabled` etc. attributes go on the distributed button,
+not on the wrapper.
+
+The following custom properties and mixins are also available for styling:
+Custom property | Description | Default
+----------------|-------------|----------
+`--paper-icon-button-light-ripple` | Mixin applied to the paper ripple | `{}`
+
+@group Paper Elements
+@element paper-icon-button-light
+@demo demo/paper-icon-button-light.html
+-->
+
+<dom-module id="paper-icon-button-light">
+  <template strip-whitespace>
+    <style>
+      :host {
+        display: inline-block;
+        position: relative;
+        width: 24px;
+        height: 24px;
+      }
+
+      paper-ripple {
+        opacity: 0.6;
+        color: currentColor;
+        @apply(--paper-icon-button-light-ripple);
+      }
+
+      :host ::slotted(button) {
+        position: relative;
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+        background: none;
+        border: none;
+        outline: none;
+        vertical-align: middle;
+        color: inherit;
+        cursor: pointer;
+        /* NOTE: Both values are needed, since some phones require the value to be `transparent`. */
+        -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+        -webkit-tap-highlight-color: transparent;
+      }
+      :host ::slotted(button[disabled]) {
+        color: #9b9b9b;
+        pointer-events: none;
+        cursor: auto;
+      }
+    </style>
+    <slot id="content"></slot>
+  </template>
+
+  <script>
+    Polymer({
+      is: 'paper-icon-button-light',
+
+      behaviors: [
+        Polymer.PaperRippleBehavior
+      ],
+
+      listeners: {
+        'down': '_rippleDown',
+        'up': '_rippleUp'
+      },
+
+      attached: function() {
+        // Assume the button has already been distributed.
+        this._button = this.getEffectiveChildren()[0];
+        this._rippleContainer = this._button;
+
+        this._button.addEventListener('focus', this._rippleDown.bind(this));
+        this._button.addEventListener('blur', this._rippleUp.bind(this));
+      },
+      _rippleDown: function() {
+        this.getRipple().uiDownAction();
+      },
+      _rippleUp: function() {
+        this.getRipple().uiUpAction();
+      },
+      /**
+       * @param {...*} var_args
+       */
+      ensureRipple: function(var_args) {
+        var lastRipple = this._ripple;
+        Polymer.PaperRippleBehavior.ensureRipple.apply(this, arguments);
+        if (this._ripple && this._ripple !== lastRipple) {
+          this._ripple.center = true;
+          this._ripple.classList.add('circle');
+        }
+      }
+    });
+  </script>
+</dom-module>

--- a/paper-icon-button-light.html
+++ b/paper-icon-button-light.html
@@ -81,7 +81,7 @@ Custom property | Description | Default
         cursor: auto;
       }
     </style>
-    <slot id="content"></slot>
+    <slot></slot>
   </template>
 
   <script>
@@ -97,7 +97,7 @@ Custom property | Description | Default
         'up': '_rippleUp'
       },
 
-      attached: function() {
+      ready: function() {
         // Assume the button has already been distributed.
         var button = this.getEffectiveChildren()[0];
         this._rippleContainer = button;

--- a/paper-icon-button-light.html
+++ b/paper-icon-button-light.html
@@ -27,8 +27,11 @@ want to use:
   </button>
 </paper-icon-button-light>
 
-Note that the `title`/`disabled` etc. attributes go on the distributed button,
-not on the wrapper.
+Note that this button is assumed to be distributed at the startup of
+`paper-icon-button-light`. Dynamically adding a `button` to this element is
+not supported.
+
+The `title`/`disabled` etc. attributes go on the distributed button, not on the wrapper.
 
 The following custom properties and mixins are also available for styling:
 Custom property | Description | Default


### PR DESCRIPTION
This re-adds the `paper-icon-button-light` element from 1.x. It's a bit more complicated now, since we don't have type extensions, and now it's a wrapper around a native `button`_ and_ an `iron-icon`.

Most of the code is copy-pasted from https://github.com/PolymerElements/paper-icon-button/blob/1.x/paper-icon-button-light.html, changed only to:
- apply the styles to the distributed `button`, not the host
- set up the focus/blur listeners on the `button`, not the host
- set the distributed `button` as the ripple container.

Tests didn't exist in 1.x and don't exist now.