### PR TITLE
drop id from iron-icon

### DIFF
--- a/paper-icon-button.html
+++ b/paper-icon-button.html
@@ -120,7 +120,7 @@ Custom property | Description | Default
       }
     </style>
 
-    <iron-icon id="icon" src="[[src]]" icon="[[icon]]" alt$="[[alt]]"></iron-icon>
+    <iron-icon src="[[src]]" icon="[[icon]]" alt$="[[alt]]"></iron-icon>
   </template>
 
   <script>


### PR DESCRIPTION
When you have multiple paper-icon-buttons on the page and are in not shadow DOM mode tools like aXe will complain about this.