### PR TITLE
`webcomponents.js` -> `webcomponents-lite.js`

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
 <head>
 
-  <script src="../webcomponentsjs/webcomponents.js"></script>
+  <script src="../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../iron-component-page/iron-component-page.html">
 
 </head>


### PR DESCRIPTION
The referenced file doesn't exist in the webcomponents repo anymore.